### PR TITLE
set COG and calc moments of inertia

### DIFF
--- a/meshmagick/inertia.py
+++ b/meshmagick/inertia.py
@@ -105,7 +105,7 @@ class RigidBodyInertia(object):
         
         The reduction point is then cog.
         """
-        self._3d_rotational_inertia -= self._huygens_transport()
+        self._3d_rotational_inertia += self._huygens_transport()
         self._point = self._cog
     
     def is_at_cog(self):

--- a/meshmagick/inertia.py
+++ b/meshmagick/inertia.py
@@ -99,6 +99,18 @@ class RigidBodyInertia(object):
         inertia = deepcopy(self)
         inertia.shift_at_cog()
         return inertia
+
+    def set_cog(self, cog):
+        """Set a new center of gravity.
+
+        Parameters
+        ----------
+        cog : array_like
+        The 3D coordinates of the center of gravity
+        """
+        assert len(cog) == 3
+        assert isinstance(cog, (tuple,list,np.ndarray))
+        self._cog = np.asarray(cog, dtype=np.float)
     
     def shift_at_cog(self):
         """Shift the inertia matrix internally at cog.

--- a/meshmagick/tests/test_inertia.py
+++ b/meshmagick/tests/test_inertia.py
@@ -4,6 +4,7 @@
 import meshmagick.mmio as mmio
 from meshmagick.mesh import Mesh
 from math import pi, fabs
+import pytest
 
 vertices, faces = mmio.load_VTP('meshmagick/tests/data/Cylinder.vtp')
 cylinder = Mesh(vertices, faces)
@@ -20,6 +21,22 @@ def test_cylinder_inertia():
     
     inertia = cylinder.eval_plain_mesh_inertias(rho_medium=1.)
     
-    assert fabs(inertia.xx - Ixx) < 1000
-    assert fabs(inertia.zz - Izz) < 1000
+    assert pytest.approx(Ixx, rel=1e-1) == inertia.xx
+    assert pytest.approx(Izz, rel=1e-1) == inertia.zz
+
+def test_move_cog():
+    xmin, xmax, ymin, ymax, zmin, zmax = cylinder.axis_aligned_bbox
+    R = (xmax-xmin)/2.
+    h = zmax-zmin
     
+    V = pi*R**2*h
+    
+    Ixx = V*(R**2+h**2/3)/4
+    Ixx_base = Ixx + V*(h/2)**2             # parallel axis theorem
+    Ixx_base2 = 1/4*V*R**2 + 1/3*V*h**2
+
+    inertia = cylinder.eval_plain_mesh_inertias(rho_medium=1.)
+    inertia.set_cog((0,0,-h/2))
+    inertia.shift_at_cog()
+
+    assert pytest.approx(Ixx_base, rel=1e-1) == inertia.xx

--- a/meshmagick/tests/test_inertia.py
+++ b/meshmagick/tests/test_inertia.py
@@ -8,34 +8,27 @@ import pytest
 
 vertices, faces = mmio.load_VTP('meshmagick/tests/data/Cylinder.vtp')
 cylinder = Mesh(vertices, faces)
+xmin, xmax, ymin, ymax, zmin, zmax = cylinder.axis_aligned_bbox
+R = (xmax-xmin)/2.
+h = zmax-zmin
+V = pi*R**2*h
+Ixx = Iyy = V*(R**2+h**2/3)/4
+Izz = V*R**2/2
 
 def test_cylinder_inertia():
-    xmin, xmax, ymin, ymax, zmin, zmax = cylinder.axis_aligned_bbox
-    R = (xmax-xmin)/2.
-    h = zmax-zmin
-    
-    V = pi*R**2*h
-    
-    Ixx = Iyy = V*(R**2+h**2/3)/4
-    Izz = V*R**2/2
-    
     inertia = cylinder.eval_plain_mesh_inertias(rho_medium=1.)
     
     assert pytest.approx(Ixx, rel=1e-1) == inertia.xx
     assert pytest.approx(Izz, rel=1e-1) == inertia.zz
 
 def test_move_cog():
-    xmin, xmax, ymin, ymax, zmin, zmax = cylinder.axis_aligned_bbox
-    R = (xmax-xmin)/2.
-    h = zmax-zmin
-    
-    V = pi*R**2*h
-    
-    Ixx = V*(R**2+h**2/3)/4
-    Ixx_base = Ixx + V*(h/2)**2             # parallel axis theorem
-    Ixx_base2 = 1/4*V*R**2 + 1/3*V*h**2
+    # parallel axis theorem to find MOI at base of cylinder
+    Ixx_base = Ixx + V*(h/2)**2             
 
+    # use meshmagick to find moments of inertia
     inertia = cylinder.eval_plain_mesh_inertias(rho_medium=1.)
+
+    # shift calculation to new cog (at base of cylinder)
     inertia.set_cog((0,0,-h/2))
     inertia.shift_at_cog()
 


### PR DESCRIPTION
Allows user to set the location of the center of gravity (`gravity_center`) and use this for calculating the moments of inertia.

<details><summary>For example</summary>
<p>

```python
import meshmagick.mmio as mmio
from meshmagick.mesh import Mesh
from math import pi, fabs
import pytest

# analytic solution
vertices, faces = mmio.load_VTP('meshmagick/tests/data/Cylinder.vtp')
cylinder = Mesh(vertices, faces)
xmin, xmax, ymin, ymax, zmin, zmax = cylinder.axis_aligned_bbox
R = (xmax-xmin)/2.
h = zmax-zmin
V = pi*R**2*h
Ixx = Iyy = V*(R**2+h**2/3)/4
Izz = V*R**2/2

# parallel axis theorem to find MOI at base of cylinder
Ixx_base = Ixx + V*(h/2)**2             

# use meshmagick to find moments of inertia
inertia = cylinder.eval_plain_mesh_inertias(rho_medium=1.)

# shift calculation to new cog (at base of cylinder)
inertia.set_cog((0,0,-h/2))
inertia.shift_at_cog()

assert pytest.approx(Ixx_base, rel=1e-1) == inertia.xx
```

<img width="624" alt="image" src="https://user-images.githubusercontent.com/5589887/110193730-f3286300-7df2-11eb-8572-82d167b061f4.png">

</p>
</details>



