### PR TITLE
use dtype names per numpy 1.20

### DIFF
--- a/meshmagick/hydrostatics.py
+++ b/meshmagick/hydrostatics.py
@@ -45,8 +45,8 @@ class Force(object):
         assert len(value) == 3
         assert mode in ('relative', 'absolute')
 
-        self.point = np.asarray(point, dtype=np.float)
-        self.value = np.asarray(value, dtype=np.float)
+        self.point = np.asarray(point, dtype=float)
+        self.value = np.asarray(value, dtype=float)
         self.name = str(name)
         self.mode = mode
 
@@ -54,7 +54,7 @@ class Force(object):
         str_repr = "Force: %s\n\tPoint: %s\n\tValue: %s\n\tMode: %s" % (self.name, self.point, self.value, self.mode)
         return str_repr
 
-    def update(self, dz=0., rot=np.eye(3, dtype=np.float)):
+    def update(self, dz=0., rot=np.eye(3, dtype=float)):
         """Updates the vertical position and orientation of the force.
         
         Parameters
@@ -98,7 +98,7 @@ class Force(object):
         fz = self.value[2]
         moment = np.cross(self.point, self.value)
         mx, my = moment[:2]
-        return np.array([fz, mx, my], dtype=np.float)
+        return np.array([fz, mx, my], dtype=float)
 
     def reset(self):  # TODO: a appeler depuis le reset de Hydrostatics
         raise NotImplementedError
@@ -143,7 +143,7 @@ class Hydrostatics(object):
         self.backup['init_mesh'] = working_mesh.copy()
         self.mesh = working_mesh.copy()
 
-        cog = np.array(cog, dtype=np.float)
+        cog = np.array(cog, dtype=float)
         assert cog.shape[0] == 3
         self.backup['gravity_center'] = cog.copy()
         self._gravity_center = cog.copy()
@@ -175,7 +175,7 @@ class Hydrostatics(object):
 
         self.animate = animate
 
-        self._rotation = np.eye(3, dtype=np.float)
+        self._rotation = np.eye(3, dtype=float)
 
         self.additional_forces = []
 
@@ -259,7 +259,7 @@ class Hydrostatics(object):
     @gravity_center.setter
     def gravity_center(self, value):
         """Set the gravity center position"""
-        value = np.asarray(value, dtype=np.float)
+        value = np.asarray(value, dtype=float)
         self.backup['gravity_center'] = value
         assert value.shape[0] == 3
         self._gravity_center = value
@@ -346,7 +346,7 @@ class Hydrostatics(object):
 
         self._update_hydrostatic_properties()
 
-        self._rotation = np.eye(3, dtype=np.float)
+        self._rotation = np.eye(3, dtype=float)
 
     def is_stable_in_roll(self):
         """Returns whether the mesh is stable in roll (GMx positive)
@@ -596,7 +596,7 @@ class Hydrostatics(object):
 
         polygons = clipper.closed_polygons
         for polygon in polygons:
-            polyverts = clipper.clipped_crown_mesh.vertices[polygon]
+            polyverts = clipper.clipped_crown_mesh.vertices[polygon] - self._gravity_center
 
             # TODO: voir si on conserve ce test...
             if np.any(np.fabs(polyverts[:, 2]) > 1e-3):
@@ -661,7 +661,7 @@ class Hydrostatics(object):
         # Assembling stiffness matrix
         stiffness_matrix = np.array([[s33, s34, s35],
                                      [s34, s44, s45],
-                                     [s35, s45, s55]], dtype=np.float)
+                                     [s35, s45, s55]], dtype=float)
 
         # Zeroing tiny coefficients
         stiffness_matrix[np.fabs(stiffness_matrix) < eps] = 0.
@@ -677,8 +677,8 @@ class Hydrostatics(object):
         self.hs_data['wet_surface_area'] = wet_surface_area
         self.hs_data['disp_volume'] = disp_volume
         self.hs_data['disp_mass'] = self._rho_water * disp_volume
-        self.hs_data['buoy_center'] = np.array([xb, yb, zb], dtype=np.float)
-        self.hs_data['flotation_center'] = np.array([x_f, y_f, 0.], dtype=np.float)
+        self.hs_data['buoy_center'] = np.array([xb, yb, zb], dtype=float)
+        self.hs_data['flotation_center'] = np.array([x_f, y_f, 0.], dtype=float)
         self.hs_data['waterplane_area'] = waterplane_area
         self.hs_data['transversal_metacentric_radius'] = transversal_metacentric_radius
         self.hs_data['longitudinal_metacentric_radius'] = longitudinal_metacentric_radius

--- a/meshmagick/inertia.py
+++ b/meshmagick/inertia.py
@@ -41,17 +41,17 @@ class RigidBodyInertia(object):
         self._mass = float(mass)
         
         assert len(cog) == 3
-        self._cog = np.asarray(cog, dtype=np.float)
+        self._cog = np.asarray(cog, dtype=float)
         
         if point is None:
             self._point = self._cog
         else:
             assert len(point) == 3
-            self._point = np.asarray(point, dtype=np.float)
+            self._point = np.asarray(point, dtype=float)
         
         self._3d_rotational_inertia = np.array([[float(xx), -float(xy), -float(xz)],
                                                 [-float(xy), float(yy), -float(yz)],
-                                                [-float(xz), -float(yz), float(zz)]], dtype=np.float)
+                                                [-float(xz), -float(yz), float(zz)]], dtype=float)
     
     @property
     def mass(self):
@@ -83,7 +83,7 @@ class RigidBodyInertia(object):
         """Set the reduction point"""
         mat_at_cog = self.at_cog.inertia_matrix
         assert len(point) == 3
-        self._point = np.asarray(point, dtype=np.float)
+        self._point = np.asarray(point, dtype=float)
         self._3d_rotational_inertia = mat_at_cog + self._huygens_transport()
     
     @property
@@ -607,7 +607,7 @@ class RotationalInertia3D(np.ndarray):
     
     def __new__(cls, xx, xy, yy, xz, yz, zz, point):
         
-        lower_triangular = np.array([xx, xy, yy, xz, yz, zz], dtype=np.float)
+        lower_triangular = np.array([xx, xy, yy, xz, yz, zz], dtype=float)
         obj = lower_triangular.view(cls)
         
         return obj
@@ -615,7 +615,7 @@ class RotationalInertia3D(np.ndarray):
     @property
     def array(self):
         print("generating full array")
-        array = np.asarray(self, dtype=np.float)[[0, 1, 3, 1, 2, 4, 3, 4, 5]]
+        array = np.asarray(self, dtype=float)[[0, 1, 3, 1, 2, 4, 3, 4, 5]]
         array[[1, 2, 3, 5, 6, 7]] *= -1
         return array.reshape((3, 3))
     
@@ -688,7 +688,7 @@ class AngularVelocityVector(np.ndarray):
     __array_priority__ = 15
     def __new__(cls, array):
         assert len(array) == 3
-        return np.asarray(array, dtype=np.float).view(cls)
+        return np.asarray(array, dtype=float).view(cls)
 
 
 if __name__ == '__main__':

--- a/meshmagick/mesh.py
+++ b/meshmagick/mesh.py
@@ -160,7 +160,7 @@ class Plane(object):
     """
     def __init__(self, normal=(0., 0., 1.), scalar=0., name=None):
 
-        normal = np.asarray(normal, dtype=np.float)
+        normal = np.asarray(normal, dtype=float)
 
         self._normal = normal / np.linalg.norm(normal)
         self._scalar = float(scalar)
@@ -185,7 +185,7 @@ class Plane(object):
     @normal.setter
     def normal(self, value):
         """Set the plane's normal"""
-        value = np.asarray(value, dtype=np.float)
+        value = np.asarray(value, dtype=float)
         self._normal = value / np.linalg.norm(value)
 
     @property
@@ -408,8 +408,8 @@ class Mesh(object):
         assert np.array(vertices).shape[1] == 3
         assert np.array(faces).shape[1] == 4
         
-        self._vertices = np.array(vertices, dtype=np.float)
-        self._faces = np.array(faces, dtype=np.int)
+        self._vertices = np.array(vertices, dtype=float)
+        self._faces = np.array(faces, dtype=int)
         self._id = next(self._ids)
 
         if not name:
@@ -625,14 +625,14 @@ class Mesh(object):
 
     @vertices.setter
     def vertices(self, value):
-        self._vertices = np.asarray(value, dtype=np.float).copy()
+        self._vertices = np.asarray(value, dtype=float).copy()
         # self._vertices.setflags(write=False)
         self.__internals__.clear()
         return
 
     @faces.setter
     def faces(self, value):
-        self._faces = np.asarray(value, dtype=np.int).copy()
+        self._faces = np.asarray(value, dtype=int).copy()
         # self._faces.setflags(write=False)
         self.__internals__.clear()
         return
@@ -648,9 +648,9 @@ class Mesh(object):
         # quads_mask = np.invert(triangle_mask)
         # nb_quads = nf - nb_triangles
 
-        faces_areas = np.zeros(nf, dtype=np.float)
-        faces_normals = np.zeros((nf, 3), dtype=np.float)
-        faces_centers = np.zeros((nf, 3), dtype=np.float)
+        faces_areas = np.zeros(nf, dtype=float)
+        faces_normals = np.zeros((nf, 3), dtype=float)
+        faces_centers = np.zeros((nf, 3), dtype=float)
 
         # Collectively dealing with triangles
         # triangles = _faces[triangle_mask]
@@ -1255,7 +1255,7 @@ class Mesh(object):
         # TODO: docstring
         # FIXME : code en doublon par rapport a la fonction _rodrigues du debut de module
         
-        angles = np.asarray(angles, dtype=np.float)
+        angles = np.asarray(angles, dtype=float)
         theta = np.linalg.norm(angles)
         if theta == 0.:
             return np.eye(3)
@@ -1590,7 +1590,7 @@ class Mesh(object):
             mesh_closed = True
 
         # Flooding the mesh to find inconsistent normals
-        type_cell = np.zeros(nf, dtype=np.int32)
+        type_cell = np.zeros(nf, dtype=int)
         type_cell[:] = 4
         type_cell[self.triangles_ids] = 3
 
@@ -1699,7 +1699,7 @@ class Mesh(object):
         nv = self.nb_vertices
         vertices, faces = self._vertices, self._faces
 
-        used_v = np.zeros(nv, dtype=np.bool)
+        used_v = np.zeros(nv, dtype=bool)
         used_v[sum(list(map(list, faces)), [])] = True
         nb_used_v = sum(used_v)
 
@@ -1893,7 +1893,7 @@ class Mesh(object):
     def _compute_faces_integrals(self, sum_faces_contrib=False): # TODO: implementer le sum_surface_contrib
 
         # TODO: Utiliser sum_faces_contrib
-        surface_integrals = np.zeros((15, self.nb_faces), dtype=np.float)
+        surface_integrals = np.zeros((15, self.nb_faces), dtype=float)
 
         # First triangles
         if self.nb_triangles > 0:
@@ -2026,7 +2026,7 @@ class Mesh(object):
 
         s0, s1, s2, s3, s4, s5, s6, s7, s8 = self.get_surface_integrals()[:9].sum(axis=1)
         
-        cog = np.array([s0, s1, s2], dtype=np.float) / surface
+        cog = np.array([s0, s1, s2], dtype=float) / surface
         
         xx = surf_density * (s7 + s8)
         yy = surf_density * (s6 + s8)
@@ -2040,7 +2040,7 @@ class Mesh(object):
     def _edges_stats(self):
         """Computes the min, max, and mean of the mesh's edge length"""
         vertices = self.vertices[self.faces]
-        edge_length = np.zeros((self.nb_faces, 4), dtype=np.float)
+        edge_length = np.zeros((self.nb_faces, 4), dtype=float)
         for i in range(4):
             edge = vertices[:, i, :] - vertices[:, i-1, :]
             edge_length[:, i] = np.sqrt(np.einsum('ij, ij -> i', edge, edge))
@@ -2078,7 +2078,7 @@ class Mesh(object):
         Explicit the integrals
         """
 
-        s_int = np.zeros((15, triangles_vertices.shape[0]), dtype=np.float)
+        s_int = np.zeros((15, triangles_vertices.shape[0]), dtype=float)
 
         point_0, point_1, point_2 = list(map(_3DPointsArray, np.rollaxis(triangles_vertices, 1, 0)))
 

--- a/meshmagick/mmio.py
+++ b/meshmagick/mmio.py
@@ -97,7 +97,7 @@ def load_RAD(filename):
     elem_section = pattern_elem_section.search(data).group(1)
     for elem in pattern_elem_line.findall(elem_section):
         faces.append(list(map(int, elem.strip().split()[3:])))
-    faces = np.asarray(faces, dtype=np.int) - 1
+    faces = np.asarray(faces, dtype=int) - 1
 
     return vertices, faces
 
@@ -147,7 +147,7 @@ def load_HST(filename):
         for node in pattern_node_line.findall(node_section):
             vertices_tmp.append(list(map(float, node.split()[1:])))
         nv_tmp = len(vertices_tmp)
-        vertices_tmp = np.asarray(vertices_tmp, dtype=np.float)
+        vertices_tmp = np.asarray(vertices_tmp, dtype=float)
         if nv == 0:
             vertices = vertices_tmp.copy()
             nv = nv_tmp
@@ -162,7 +162,7 @@ def load_HST(filename):
         for elem in pattern_elem_line.findall(elem_section):
             faces_tmp.append(list(map(int, elem.split())))
         nf_tmp = len(faces_tmp)
-        faces_tmp = np.asarray(faces_tmp, dtype=np.int)
+        faces_tmp = np.asarray(faces_tmp, dtype=int)
         if nf == 0:
             faces = faces_tmp.copy()
             nf = nf_tmp
@@ -199,7 +199,7 @@ def load_DAT(filename):
         nodes.append(node_split[1:])
         node_dict[node_split[0]] = inode
         
-    vertices = np.array(nodes, dtype=np.float)
+    vertices = np.array(nodes, dtype=float)
 
     faces = []
 
@@ -237,7 +237,7 @@ def load_DAT(filename):
 
             faces.append(quadrangle)
 
-    faces = np.array(faces, dtype=np.int)
+    faces = np.array(faces, dtype=int)
     
     return vertices, faces
 
@@ -344,7 +344,7 @@ def load_INP(filename):
         # Detecting renumberings to do
         real_idx = 0
         # renumberings = []
-        id_new = - np.ones(max(idx_array) + 1, dtype=np.int)
+        id_new = - np.ones(max(idx_array) + 1, dtype=int)
         # FIXME: cette partie est tres buggee !!!
         for i, idx in enumerate(idx_array):
             id_new[idx] = i+1
@@ -371,7 +371,7 @@ def load_INP(filename):
     for field in layout:
         file = field['INPUT']
         if field['type'] == 'NODE':
-            nodes = np.asarray(mesh_files[file]['NODE_SECTION'], dtype=np.float)
+            nodes = np.asarray(mesh_files[file]['NODE_SECTION'], dtype=float)
             # Translation of nodes according to frame option id any
             nodes += frames[field['FRAME']]  # TODO: s'assurer que frame est une options obligatoire...
 
@@ -390,7 +390,7 @@ def load_INP(filename):
                 increment = True
         else:  # this is an ELEMENT section
             elem_section = np.asarray(mesh_files[file]['ELEM_SECTIONS'][mesh_files[file]['nb_elem_sections_used']],
-                                      dtype=np.int)
+                                      dtype=int)
 
             mesh_files[file]['nb_elem_sections_used'] += 1
             if mesh_files[file]['nb_elem_sections_used'] == mesh_files[file]['nb_elem_sections']:
@@ -450,8 +450,8 @@ def load_TEC(filename):
     nv = int(nv)
     nf = int(nf)
 
-    vertices = np.asarray(list(map(float, vertices.split())), dtype=np.float).reshape((nv, -1))[:, :3]
-    faces = np.asarray(list(map(int, faces.split())), dtype=np.int).reshape((nf, 4))-1
+    vertices = np.asarray(list(map(float, vertices.split())), dtype=float).reshape((nv, -1))[:, :3]
+    faces = np.asarray(list(map(int, faces.split())), dtype=int).reshape((nf, 4))-1
 
     return vertices, faces
 
@@ -601,12 +601,12 @@ def _dump_vtk(vtk_mesh):
     """
 
     nv = vtk_mesh.GetNumberOfPoints()
-    vertices = np.zeros((nv, 3), dtype=np.float)
+    vertices = np.zeros((nv, 3), dtype=float)
     for k in range(nv):
         vertices[k] = np.array(vtk_mesh.GetPoint(k))
 
     nf = vtk_mesh.GetNumberOfCells()
-    faces = np.zeros((nf, 4), dtype=np.int)
+    faces = np.zeros((nf, 4), dtype=int)
     for k in range(nf):
         cell = vtk_mesh.GetCell(k)
         nv_facet = cell.GetNumberOfPoints()
@@ -652,11 +652,11 @@ def load_STL(filename):
     data = reader.GetOutputDataObject(0)
 
     nv = data.GetNumberOfPoints()
-    vertices = np.zeros((nv, 3), dtype=np.float)
+    vertices = np.zeros((nv, 3), dtype=float)
     for k in range(nv):
         vertices[k] = np.array(data.GetPoint(k))
     nf = data.GetNumberOfCells()
-    faces = np.zeros((nf, 4), dtype=np.int)
+    faces = np.zeros((nf, 4), dtype=int)
     for k in range(nf):
         cell = data.GetCell(k)
         if cell is not None:
@@ -724,12 +724,12 @@ def load_NAT(filename):
     vertices = []
     for i in range(nv):
         vertices.append(list(map(float, ifile.readline().split())))
-    vertices = np.array(vertices, dtype=np.float)
+    vertices = np.array(vertices, dtype=float)
 
     faces = []
     for i in range(nf):
         faces.append(list(map(int, ifile.readline().split())))
-    faces = np.array(faces, dtype=np.int)
+    faces = np.array(faces, dtype=int)
 
     ifile.close()
     return vertices, faces-1
@@ -774,8 +774,8 @@ def load_GDF(filename):
     line = ifile.readline().split()
     nf = int(line[0])
 
-    vertices = np.zeros((4 * nf, 3), dtype=np.float)
-    faces = np.zeros((nf, 4), dtype=np.int)
+    vertices = np.zeros((4 * nf, 3), dtype=float)
+    faces = np.zeros((nf, 4), dtype=int)
 
     iv = -1
     for icell in range(nf):
@@ -823,7 +823,7 @@ def load_MAR(filename):
             break
         vertices.append(list(map(float, line[1:])))
 
-    vertices = np.array(vertices, dtype=np.float)
+    vertices = np.array(vertices, dtype=float)
     faces = []
     while 1:
         line = ifile.readline()
@@ -832,7 +832,7 @@ def load_MAR(filename):
             break
         faces.append(list(map(int, line)))
 
-    faces = np.array(faces, dtype=np.int)
+    faces = np.array(faces, dtype=int)
 
     ifile.close()
 
@@ -869,7 +869,7 @@ def load_MSH(filename):
     nb_nodes, nodes_data = re.search(r'\$Nodes\n(\d+)\n(.+)\$EndNodes', data, re.DOTALL).groups()
     nb_elts, elts_data = re.search(r'\$Elements\n(\d+)\n(.+)\$EndElements', data, re.DOTALL).groups()
 
-    vertices = np.asarray(list(map(float, nodes_data.split())), dtype=np.float).reshape((-1, 4))[:, 1:]
+    vertices = np.asarray(list(map(float, nodes_data.split())), dtype=float).reshape((-1, 4))[:, 1:]
     vertices = np.ascontiguousarray(vertices)
     faces = []
 
@@ -885,7 +885,7 @@ def load_MSH(filename):
         quadrangle = quad_elt[-4:]
         faces.append(quadrangle)
 
-    faces = np.asarray(faces, dtype=np.int) - 1
+    faces = np.asarray(faces, dtype=int) - 1
 
     return vertices, faces
 
@@ -939,13 +939,13 @@ def load_MED(filename):
     file.close()
 
     if nb_triangles == 0:
-        triangles = np.zeros((0, 4), dtype=np.int)
+        triangles = np.zeros((0, 4), dtype=int)
     else:
         triangles = np.column_stack((triangles, triangles[:, 0]))
     if nb_quadrangles == 0:
-        quadrangles = np.zeros((0, 4), dtype=np.int)
+        quadrangles = np.zeros((0, 4), dtype=int)
 
-    faces = np.zeros((nb_triangles+nb_quadrangles, 4), dtype=np.int)
+    faces = np.zeros((nb_triangles+nb_quadrangles, 4), dtype=int)
     faces[:nb_triangles] = triangles
     # faces[:nb_triangles, -1] = triangles[:, 0]
     faces[nb_triangles:] = quadrangles
@@ -1023,12 +1023,12 @@ def load_NEM(filename):
     vertices = []
     for ivertex in range(nv):
         vertices.append(list(map(float, ifile.readline().split())))
-    vertices = np.asarray(vertices, dtype=np.float)
+    vertices = np.asarray(vertices, dtype=float)
     
     faces = []
     for iface in range(nf):
         faces.append(list(map(int, ifile.readline().split())))
-    faces = np.asarray(faces, dtype=np.int)
+    faces = np.asarray(faces, dtype=int)
     faces -= 1
     
     return vertices, faces


### PR DESCRIPTION
I was receiving a bunch of warnings when running tests like the following due to deprecation of the `dtype` names in numpy 1.20 (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), so I updated these throughout.

```
meshmagick/inertia.py:86
meshmagick/meshmagick/inertia.py:86: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    self._point = np.asarray(point, dtype=np.float)
```
