### PR TITLE
Generalize GDF read to accept multiple formats

### DIFF
--- a/meshmagick/mmio.py
+++ b/meshmagick/mmio.py
@@ -777,13 +777,20 @@ def load_GDF(filename):
     vertices = np.zeros((4 * nf, 3), dtype=np.float)
     faces = np.zeros((nf, 4), dtype=np.int)
 
-    iv = -1
+    iv = 0
     for icell in range(nf):
+        
+        n_coords = 0
+        face_coords = np.zeros((12,), dtype=np.float)
+        
+        while n_coords < 12:
+            line = np.array(ifile.readline().split())
+            face_coords[n_coords:n_coords+len(line)] = line
+            n_coords += len(line)
 
-        for k in range(4):
-            iv += 1
-            vertices[iv, :] = np.array(ifile.readline().split())[:3]
-            faces[icell, k] = iv
+        vertices[iv:iv+4, :] = np.split(face_coords, 4)
+        faces[icell, :] = np.arange(iv, iv+4)
+        iv += 4
 
     ifile.close()
 


### PR DESCRIPTION
Resolves #31

Previously, `load_GDF` only accepted GDF files that had each vertex on its own line, so the coordinates for each face were 4x3. However, GDF files can also have other formats, such as all four vertices sharing a line, so each face is 1x12. This makes it so `load_GDF` can parse any format of GDF file regardless of line breaks, as long as each face is separated by a line break.